### PR TITLE
fix: disable the command palette

### DIFF
--- a/src/pypi_search_tui/app.py
+++ b/src/pypi_search_tui/app.py
@@ -18,6 +18,8 @@ class Package:
 
 
 class PyPISearchApp(App):
+    ENABLE_COMMAND_PALETTE = False
+
     CSS = """
     Container {
         height: 13;


### PR DESCRIPTION
This app (currently) doesn't utilise the command palette anyway, and it doesn't play nicely with inline mode as of Textual v0.55.1 (see Textualize/textual#4385)