### PR TITLE
feat: add vim-like navigation for table

### DIFF
--- a/src/pypi_search_tui/app.py
+++ b/src/pypi_search_tui/app.py
@@ -22,6 +22,8 @@ class Package:
 class SearchResultsTable(DataTable):
     BINDINGS = [
         Binding("enter", "select_cursor", "View on PyPI", show=True),
+        Binding("up,k", "cursor_up", "Cursor Up", show=False),
+        Binding("down,j", "cursor_down", "Cursor Down", show=False),
     ]
 
 


### PR DESCRIPTION
Add vim-like navigation of the search results table with <kbd>j</kbd> and <kbd>k</kbd>.